### PR TITLE
feat: Content Disposition and ACL support

### DIFF
--- a/policy.go
+++ b/policy.go
@@ -22,10 +22,12 @@ import (
 // for POST requests to S3 using Signing V4.
 type UploadConfig struct {
 	// Required
-	BucketName  string
-	ObjectKey   string
-	ContentType string
-	FileSize    int64
+	BucketName         string
+	ObjectKey          string
+	ContentType        string
+	ContentDisposition string
+	ACL                string
+	FileSize           int64
 	// Optional
 	UploadURL  string
 	Expiration time.Duration
@@ -84,6 +86,8 @@ func (s3 *S3) CreateUploadPolicies(uploadConfig UploadConfig) (UploadPolicies, e
 	if uploadURL == "" {
 		uploadURL = fmt.Sprintf(defaultUploadURLFormat, uploadConfig.BucketName)
 	}
+
+	// essential fields
 	form := map[string]string{
 		"key":              uploadConfig.ObjectKey,
 		"Content-Type":     uploadConfig.ContentType,
@@ -93,6 +97,16 @@ func (s3 *S3) CreateUploadPolicies(uploadConfig UploadConfig) (UploadPolicies, e
 		"Policy":           policy,
 		"X-Amz-Signature":  signature,
 	}
+
+	// optional fields
+	if uploadConfig.ContentDisposition != "" {
+		form["Content-Disposition"] = uploadConfig.ContentDisposition
+	}
+
+	if uploadConfig.ACL != "" {
+		form["x-amz-acl"] = uploadConfig.ACL
+	}
+
 	for k, v := range uploadConfig.MetaData {
 		form[k] = v
 	}

--- a/simples3.go
+++ b/simples3.go
@@ -43,11 +43,17 @@ type DownloadInput struct {
 
 // UploadInput is passed to FileUpload as a parameter.
 type UploadInput struct {
+	// essential fields
 	Bucket      string
 	ObjectKey   string
 	FileName    string
 	ContentType string
-	Body        io.ReadSeeker
+
+	// optional fields
+	ContentDisposition string
+	ACL                string
+
+	Body io.ReadSeeker
 }
 
 // UploadResponse receives the following XML
@@ -288,11 +294,13 @@ func (s3 *S3) FileUpload(u UploadInput) (UploadResponse, error) {
 		return UploadResponse{}, err
 	}
 	policies, err := s3.CreateUploadPolicies(UploadConfig{
-		UploadURL:   s3.getURL(u.Bucket),
-		BucketName:  u.Bucket,
-		ObjectKey:   u.ObjectKey,
-		ContentType: u.ContentType,
-		FileSize:    fSize,
+		UploadURL:          s3.getURL(u.Bucket),
+		BucketName:         u.Bucket,
+		ObjectKey:          u.ObjectKey,
+		ContentType:        u.ContentType,
+		ContentDisposition: u.ContentDisposition,
+		ACL:                u.ACL,
+		FileSize:           fSize,
 		MetaData: map[string]string{
 			"success_action_status": "201", // returns XML doc on success
 		},


### PR DESCRIPTION
This commit adds two extra fields to the upload input
to add support for setting Content-Disposition and the
x-amz-acl params.