### PR TITLE
Rework presign to allow signature of endpoint given clients

### DIFF
--- a/presigned_test.go
+++ b/presigned_test.go
@@ -60,10 +60,10 @@ func TestS3_GeneratePresignedURL_Personal(t *testing.T) {
 			os.Getenv("AWS_S3_ACCESS_KEY"),
 			os.Getenv("AWS_S3_SECRET_KEY"),
 		)
+		s.Endpoint = os.Getenv("AWS_S3_ENDPOINT")
 		dontwant := ""
 		if got := s.GeneratePresignedURL(PresignedInput{
 			Bucket:        os.Getenv("AWS_S3_BUCKET"),
-			Endpoint:      os.Getenv("AWS_S3_ENDPOINT"),
 			ObjectKey:     "test1.txt",
 			Method:        "GET",
 			Timestamp:     nowTime(),
@@ -81,10 +81,10 @@ func TestS3_GeneratePresignedURL_ExtraHeader(t *testing.T) {
 			os.Getenv("AWS_S3_ACCESS_KEY"),
 			os.Getenv("AWS_S3_SECRET_KEY"),
 		)
+		s.Endpoint = os.Getenv("AWS_S3_ENDPOINT")
 		dontwant := ""
 		if got := s.GeneratePresignedURL(PresignedInput{
 			Bucket:        os.Getenv("AWS_S3_BUCKET"),
-			Endpoint:      os.Getenv("AWS_S3_ENDPOINT"),
 			ObjectKey:     "test2.txt",
 			Method:        "GET",
 			Timestamp:     nowTime(),
@@ -105,10 +105,10 @@ func TestS3_GeneratePresignedURL_PUT(t *testing.T) {
 			os.Getenv("AWS_S3_ACCESS_KEY"),
 			os.Getenv("AWS_S3_SECRET_KEY"),
 		)
+		s.Endpoint = os.Getenv("AWS_S3_ENDPOINT")
 		dontwant := ""
 		if got := s.GeneratePresignedURL(PresignedInput{
 			Bucket:        os.Getenv("AWS_S3_BUCKET"),
-			Endpoint:      os.Getenv("AWS_S3_ENDPOINT"),
 			ObjectKey:     "test2.txt",
 			Method:        "PUT",
 			Timestamp:     nowTime(),
@@ -126,13 +126,13 @@ func BenchmarkS3_GeneratePresigned(b *testing.B) {
 		os.Getenv("AWS_S3_ACCESS_KEY"),
 		os.Getenv("AWS_S3_SECRET_KEY"),
 	)
+	s.Endpoint = os.Getenv("AWS_S3_ENDPOINT")
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		s.GeneratePresignedURL(PresignedInput{
 			Bucket:        os.Getenv("AWS_S3_BUCKET"),
-			Endpoint:      os.Getenv("AWS_S3_ENDPOINT"),
 			ObjectKey:     "test.txt",
 			Method:        "GET",
 			Timestamp:     nowTime(),


### PR DESCRIPTION
Hi,

It is not possible to use the presign function with custom endpoint (non-AWS), especially with endpoint that includes bucket name in path instead of virtual host: the hostname is systematically tweaked to add the unwanted bucket name.
See https://github.com/knadh/listmonk/issues/1782

Here is a patch to allow this library to presign URL for Minio and other non-AWS S3 providers. Perhaps it lacks a force_path_style attribute something to mock the aws library behavior in this case.

As the Endpoint (in fact hostname) is redundant in presign request, I remove it in favor of the endpoint given in the s3 client.

Tested with Minio and Oracle Cloud Infrastructure, should be tested with AWS S3 (I don't have an account).