### PR TITLE
fix: expired token error while generating presigned URLs

### DIFF
--- a/presigned.go
+++ b/presigned.go
@@ -31,6 +31,10 @@ type PresignedInput struct {
 // for Authentication using Query Parameters.
 // (https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html)
 func (s3 *S3) GeneratePresignedURL(in PresignedInput) string {
+	if err := s3.renewIAMToken(); err != nil {
+		return ""
+	}
+
 	var (
 		nowTime = nowTime()
 


### PR DESCRIPTION
Adds renewIAMToken() call in GeneratePresignedURL.
On token expiry, GeneratePresignedURL would not renew it until other methods that renew tokens are called.